### PR TITLE
Implement an image provider using the image cache

### DIFF
--- a/lib/cached_network_image.dart
+++ b/lib/cached_network_image.dart
@@ -3,13 +3,17 @@ library cached_network_image;
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:http/http.dart' as http;
 import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:synchronized/synchronized.dart';
 import 'package:uuid/uuid.dart';
+import 'dart:ui' as ui show Image, decodeImageFromList;
 
 
 /**
@@ -268,4 +272,71 @@ class CacheObject {
   setPath(String path) {
     _map["path"] = path;
   }
+}
+
+class CachedNetworkImageProvider extends ImageProvider<CachedNetworkImageProvider> {
+
+  const CachedNetworkImageProvider(this.url, { this.scale: 1.0 })
+      : assert(url != null),
+        assert(scale != null);
+
+  final String url;
+
+  final double scale;
+
+  @override
+  Future<CachedNetworkImageProvider> obtainKey(ImageConfiguration configuration) {
+    return new SynchronousFuture<CachedNetworkImageProvider>(this);
+  }
+
+  @override
+  ImageStreamCompleter load(CachedNetworkImageProvider key) {
+    return new OneFrameImageStreamCompleter(
+        _loadAsync(key),
+        informationCollector: (StringBuffer information) {
+          information.writeln('Image provider: $this');
+          information.write('Image key: $key');
+        }
+    );
+  }
+
+  Future<ImageInfo> _loadAsync(CachedNetworkImageProvider key) async {
+    var cacheManager = await CacheManager.getInstance();
+    var file = await cacheManager.getFile(url);
+    return _loadAsyncFromFile(key, file);
+  }
+
+  Future<ImageInfo> _loadAsyncFromFile(CachedNetworkImageProvider key, File file) async {
+    assert(key == this);
+
+    final Uint8List bytes = await file.readAsBytes();
+    if (bytes.lengthInBytes == 0)
+      return null;
+
+    final ui.Image image = await decodeImageFromList(bytes);
+    if (image == null)
+      return null;
+
+    return new ImageInfo(
+      image: image,
+      scale: key.scale,
+    );
+  }
+
+
+  @override
+  bool operator ==(dynamic other) {
+    if (other.runtimeType != runtimeType)
+      return false;
+    final CachedNetworkImageProvider typedOther = other;
+    return url == typedOther.url
+        && scale == typedOther.scale;
+  }
+
+  @override
+  int get hashCode => hashValues(url, scale);
+
+  @override
+  String toString() => '$runtimeType("$url", scale: $scale)';
+
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,3 @@ dependencies:
 
 dev_dependencies:
   test: ^0.12.0
-
-# The following section is specific to Flutter.
-flutter:


### PR DESCRIPTION
Simple image provider using the image disk cache.

Could be used for exemple with [DecorationImage](https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/painting/decoration_image.dart)