### PR TITLE
Return a Future that resolved to error instead of throwing exception when incorrect url is provided

### DIFF
--- a/lib/cached_network_image.dart
+++ b/lib/cached_network_image.dart
@@ -473,7 +473,7 @@ class CachedNetworkImageProvider
     var file = await cacheManager.getFile(url, headers: headers);
     if (file == null) {
       if (errorListener != null) errorListener();
-      throw new Exception("Couldn't download or retreive file.");
+      return Future<ui.Codec>.error("Couldn't download or retreive file.");
     }
     return await _loadAsyncFromFile(key, file);
   }


### PR DESCRIPTION
### Currently
When incorrect url is provided (`http://xxxxxx.xxxx/xxx.jpg`) is provided the app throw Exception and just crashed.

### Changed
I think the Future that resolved to error should be returned so that the `errorWidget` could be shown instead of the app crashing.