### PR TITLE
Introduce generic CacheManager

### DIFF
--- a/lib/cached_network_image.dart
+++ b/lib/cached_network_image.dart
@@ -1,4 +1,5 @@
 library cached_network_image;
 
+export 'src/cached_image_manager.dart';
 export 'src/cached_image_widget.dart';
 export 'src/cached_network_image_provider.dart';

--- a/lib/src/cached_image_manager.dart
+++ b/lib/src/cached_image_manager.dart
@@ -1,0 +1,64 @@
+import 'dart:async';
+import 'dart:io';
+import 'package:flutter_cache_manager/flutter_cache_manager.dart' as fcm;
+
+/// Manager for getting [CachedImage].
+abstract class CacheManager {
+  /// Try to get the image from memory directly.
+  CachedImage getImageFromMemory(String imageUrl);
+
+  /// Get the image from the cache.
+  /// Download form [url] if the cache was missing or expired. And the [headers]
+  /// can be used for example for authentication.
+  ///
+  /// The files are returned as stream. First the cached file if available, when the
+  /// cached file is expired the newly downloaded file is returned afterwards.
+  Stream<CachedImage> getImage(String url, {Map<String, String> headers});
+
+  /// Try to get the cached image file. Download form [url] when missing.
+  Future<File> getImageFile(String url, {Map<String, String> headers});
+}
+
+class CachedImage {
+  final String originalUrl;
+  final DateTime validTill;
+  final File file;
+
+  CachedImage(this.originalUrl, this.validTill, this.file);
+}
+
+/// Default [CacheManager] implementation by package 'flutter_cache_manager'.
+/// See https://pub.dev/packages/flutter_cache_manager for more details.
+class DefaultCacheManager implements CacheManager {
+  static DefaultCacheManager _instance;
+
+  factory DefaultCacheManager() {
+    if (_instance == null) {
+      _instance = DefaultCacheManager._(fcm.DefaultCacheManager());
+    }
+    return _instance;
+  }
+  final fcm.BaseCacheManager manager;
+
+  DefaultCacheManager._(this.manager);
+
+  @override
+  Stream<CachedImage> getImage(String imageUrl, {Map<String, String> headers}) {
+    return manager.getFile(imageUrl, headers: headers).map(_convert);
+  }
+
+  @override
+  CachedImage getImageFromMemory(String imageUrl) {
+    return _convert(manager.getFileFromMemory(imageUrl));
+  }
+
+  CachedImage _convert(fcm.FileInfo info) {
+    if (info == null) return null;
+    return CachedImage(info.originalUrl, info.validTill, info.file);
+  }
+
+  @override
+  Future<File> getImageFile(String url, {Map<String, String> headers}) {
+    return manager.getSingleFile(url, headers: headers);
+  }
+}

--- a/lib/src/cached_network_image_provider.dart
+++ b/lib/src/cached_network_image_provider.dart
@@ -5,7 +5,8 @@ import 'dart:ui' as ui show instantiateImageCodec, Codec;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+
+import 'cached_image_manager.dart';
 
 typedef void ErrorListener();
 
@@ -23,7 +24,7 @@ class CachedNetworkImageProvider
       : assert(url != null),
         assert(scale != null);
 
-  final BaseCacheManager cacheManager;
+  final CacheManager cacheManager;
 
   /// Web url of the image to load
   final String url;
@@ -67,7 +68,7 @@ class CachedNetworkImageProvider
 
   Future<ui.Codec> _loadAsync(CachedNetworkImageProvider key) async {
     var mngr = cacheManager ?? DefaultCacheManager();
-    var file = await mngr.getSingleFile(url, headers: headers);
+    var file = await mngr.getImageFile(url, headers: headers);
     if (file == null) {
       if (errorListener != null) errorListener();
       return Future<ui.Codec>.error("Couldn't download or retrieve file.");

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,3 +14,6 @@ dependencies:
 
 dev_dependencies:
   test: ^1.3.0
+  mockito: ^4.1.1
+  flutter_test: 
+    sdk: flutter

--- a/test/cached_network_image_test.dart
+++ b/test/cached_network_image_test.dart
@@ -1,7 +1,61 @@
-import 'package:test/test.dart';
+import 'dart:convert';
 
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+import 'mock_cached_image_manager.dart';
 
 void main() {
-
+  group("$CachedNetworkImage", () {
+    var cacheManager = MockCacheManager();
+    when(cacheManager.getImage("https://test/1.png")).thenAnswer((_) async* {
+      await Future.delayed(Duration(milliseconds: 100));
+      yield CachedImage(
+          "https://test/1.png",
+          DateTime.now(),
+          mockFile(
+            () => base64.decode(
+                'UklGRjYAAABXRUJQVlA4ICoAAAAQAgCdASoBAAEAAYcIhYWIhYSIiIIADA1gAAQAAAEAAAEAAP74h4AAAAA='),
+          ));
+    });
+    when(cacheManager.getImage("https://test/error")).thenAnswer((_) async* {
+      await Future.delayed(Duration(milliseconds: 100));
+      throw Exception("error");
+    });
+    testWidgets('test placeholder', (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: CachedNetworkImage(
+            imageUrl: "https://test/1.png",
+            cacheManager: cacheManager,
+            fadeInDuration: Duration.zero,
+            placeholder: (_, __) => Text("Placeholder"),
+          ),
+        ),
+      ));
+      expect(find.byType(CachedNetworkImage), findsOneWidget);
+      expect(find.text("Placeholder"), findsOneWidget, reason: "Placeholder");
+      await tester.pump(Duration(milliseconds: 10));
+      expect(find.text("Placeholder"), findsOneWidget, reason: "Loading");
+      await tester.pump(Duration(milliseconds: 100));
+      expect(find.byType(Image), findsOneWidget, reason: "Loaded");
+    });
+    testWidgets('test error', (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: CachedNetworkImage(
+            imageUrl: "https://test/error",
+            cacheManager: cacheManager,
+            errorWidget: (_, __, ___) => Text("Loading Error"),
+          ),
+        ),
+      ));
+      expect(find.byType(CachedNetworkImage), findsOneWidget);
+      await tester.pump(Duration(milliseconds: 100));
+      expect(find.text("Loading Error"), findsOneWidget, reason: "failed");
+    });
+  });
 }

--- a/test/mock_cached_image_manager.dart
+++ b/test/mock_cached_image_manager.dart
@@ -1,0 +1,16 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+import 'package:mockito/mockito.dart';
+import 'package:cached_network_image/src/cached_image_manager.dart';
+
+class MockCacheManager extends Mock implements CacheManager {}
+
+class MockFile extends Mock implements File {}
+
+File mockFile(Uint8List bytes()) {
+  var f = MockFile();
+  when(f.readAsBytes()).thenAnswer((_) => Future.sync(bytes));
+  when(f.readAsBytesSync()).thenReturn(bytes());
+  return f;
+}


### PR DESCRIPTION
This PR contains __BREAKING CHANGE__:
The signature of field `cacheManager` in `CachedNetworkImage` will be replaced with new `CacheManager` (NOT the `BaseCacheManager` in `flutter_cache_manager` library).
Therefore, users can custom `CacheManager` totally by themselves.

Changes in this PR: 
1. The new DefaultCacheManager wraps old 'DefaultCacheManager' of package 'flutter_cache_manager'.
2. Add some tests.
