### PR TITLE
Update cached_network_image_provider.dart

### DIFF
--- a/lib/src/cached_network_image_provider.dart
+++ b/lib/src/cached_network_image_provider.dart
@@ -39,7 +39,7 @@ class CachedNetworkImageProvider
   }
 
   @override
-  ImageStreamCompleter load(CachedNetworkImageProvider key) {
+  ImageStreamCompleter load(CachedNetworkImageProvider key, DecoderCallback decode) {
     return MultiFrameImageStreamCompleter(
       codec: _loadAsync(key),
       scale: key.scale,


### PR DESCRIPTION
Update method signature for Flutter 1.12

ImageStreamCompleter's load method signature has changed in the latest release of Flutter. This update reflects that change.