### PR TITLE
added DecoderCallback decode in CachedNetworkImageProvider -> load

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 build/
 packages
 .packages
+.dart_tool
+.flutter-plugins-dependencies
 
 # Or the files created by dart2js.
 *.dart.js

--- a/lib/src/cached_network_image_provider.dart
+++ b/lib/src/cached_network_image_provider.dart
@@ -39,7 +39,8 @@ class CachedNetworkImageProvider
   }
 
   @override
-  ImageStreamCompleter load(CachedNetworkImageProvider key) {
+  ImageStreamCompleter load(CachedNetworkImageProvider key, DecoderCallback decode) {
+    // TODO: handle decode callback
     return MultiFrameImageStreamCompleter(
       codec: _loadAsync(key),
       scale: key.scale,


### PR DESCRIPTION
In Flutter `1.12.13`, the `load` method in `ImageProvider` is changed and it requires one more parameter. Hence, added the parameter in `CachedNetworkImageProvider`.

Request to merge PR and handle the callback added.