### PR TITLE
Added web support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ CachedNetworkImage(
 The cached network images stores and retrieves files using the [flutter_cache_manager](https://pub.dartlang.org/packages/flutter_cache_manager). 
 
 ## Web support
-Web support uses standard widget Image without any cache engine. Therefore, some properties are ignored in web version. 
+Web support uses standard widget "Image" and standard browser caching. Therefore, some properties are ignored (only in web version). 
 
 I was unable to isolate BaseCacheManager from conditional import so I had to introduce a breaking change. This parameter is not available anymore and you are not capable of use another cache manager instead of the default one
 

--- a/README.md
+++ b/README.md
@@ -42,3 +42,9 @@ CachedNetworkImage(
 
 ## How it works
 The cached network images stores and retrieves files using the [flutter_cache_manager](https://pub.dartlang.org/packages/flutter_cache_manager). 
+
+## Web support
+Web support uses standard widget Image without any cache engine. Therefore, some properties are ignored in web version. 
+
+I was unable to isolate BaseCacheManager from conditional import so I had to introduce a breaking change. This parameter is not available anymore and you are not capable of use another cache manager instead of the default one
+

--- a/example/.flutter-plugins-dependencies
+++ b/example/.flutter-plugins-dependencies
@@ -1,0 +1,1 @@
+{"_info":"// This is a generated file; do not edit or check into version control.","dependencyGraph":[{"name":"path_provider","dependencies":[]},{"name":"sqflite","dependencies":[]}]}

--- a/lib/cached_network_image.dart
+++ b/lib/cached_network_image.dart
@@ -1,4 +1,5 @@
 library cached_network_image;
 
-export 'src/cached_image_widget.dart';
+export 'src/cached_network_image.dart';
+export 'src/cached_image_types.dart';
 export 'src/cached_network_image_provider.dart';

--- a/lib/src/base_cached_network_image.dart
+++ b/lib/src/base_cached_network_image.dart
@@ -1,0 +1,5 @@
+import 'package:flutter/material.dart';
+import 'cached_network_image.dart';
+
+abstract class BaseCachedNetworkImage extends StatefulWidget implements CachedNetworkImage {
+}

--- a/lib/src/browser_cached_network_image.dart
+++ b/lib/src/browser_cached_network_image.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'base_cached_network_image.dart';
+import 'cached_image_types.dart';
+
+BaseCachedNetworkImage createCachedNetworkImage(
+        {Key key,
+        @required String imageUrl,
+        ImageWidgetBuilder imageBuilder,
+        PlaceholderWidgetBuilder placeholder,
+        LoadingErrorWidgetBuilder errorWidget,
+        Duration fadeOutDuration,
+        Curve fadeOutCurve: Curves.easeOut,
+        Duration fadeInDuration,
+        Curve fadeInCurve,
+        double width,
+        double height,
+        BoxFit fit,
+        AlignmentGeometry alignment,
+        ImageRepeat repeat,
+        bool matchTextDirection,
+        final Map<String, String> httpHeaders,
+        bool useOldImageOnUrlChange,
+        Color color,
+        FilterQuality filterQuality,
+        BlendMode colorBlendMode,
+        Duration placeholderFadeInDuration}) =>
+    BrowserCachedNetworkImage(
+        key: key,
+        imageUrl: imageUrl,
+        imageBuilder: imageBuilder,
+        placeholder: placeholder,
+        errorWidget: errorWidget,
+        fadeOutDuration: fadeOutDuration,
+        fadeOutCurve: fadeOutCurve,
+        fadeInDuration: fadeInDuration,
+        fadeInCurve: fadeInCurve,
+        width: width,
+        height: height,
+        fit: fit,
+        alignment: alignment,
+        repeat: repeat,
+        matchTextDirection: matchTextDirection,
+        httpHeaders: httpHeaders,
+        useOldImageOnUrlChange: useOldImageOnUrlChange,
+        color: color,
+        filterQuality: filterQuality,
+        colorBlendMode: colorBlendMode,
+        placeholderFadeInDuration: placeholderFadeInDuration);
+
+class BrowserCachedNetworkImage extends BaseCachedNetworkImage {
+  final Image _instance;
+  BrowserCachedNetworkImage(
+      {Key key,
+      @required String imageUrl,
+      ImageWidgetBuilder imageBuilder,
+      PlaceholderWidgetBuilder placeholder,
+      LoadingErrorWidgetBuilder errorWidget,
+      Duration fadeOutDuration,
+      Curve fadeOutCurve: Curves.easeOut,
+      Duration fadeInDuration,
+      Curve fadeInCurve,
+      double width,
+      double height,
+      BoxFit fit,
+      AlignmentGeometry alignment,
+      ImageRepeat repeat,
+      bool matchTextDirection,
+      final Map<String, String> httpHeaders,
+      bool useOldImageOnUrlChange,
+      Color color,
+      FilterQuality filterQuality,
+      BlendMode colorBlendMode,
+      Duration placeholderFadeInDuration})
+      : _instance = Image.network(imageUrl,
+            key: key,
+            width: width,
+            height: height,
+            color: color,
+            colorBlendMode: colorBlendMode,
+            fit: fit,
+            alignment: alignment,
+            repeat: repeat,
+            filterQuality: filterQuality,
+            headers: httpHeaders);
+
+  @override
+  _BrowserCachedNetworkImageState createState() =>
+      _BrowserCachedNetworkImageState();
+}
+
+class _BrowserCachedNetworkImageState extends State<BrowserCachedNetworkImage> {
+  @override
+  Widget build(BuildContext context) {
+    return widget._instance;
+  }
+}

--- a/lib/src/cached_image_types.dart
+++ b/lib/src/cached_image_types.dart
@@ -1,0 +1,8 @@
+import 'package:flutter/material.dart';
+
+typedef Widget ImageWidgetBuilder(
+    BuildContext context, ImageProvider imageProvider);
+typedef Widget PlaceholderWidgetBuilder(BuildContext context, String url);
+typedef Widget LoadingErrorWidgetBuilder(
+    BuildContext context, String url, Object error);
+

--- a/lib/src/cached_image_widget.dart
+++ b/lib/src/cached_image_widget.dart
@@ -2,12 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
-
-typedef Widget ImageWidgetBuilder(
-    BuildContext context, ImageProvider imageProvider);
-typedef Widget PlaceholderWidgetBuilder(BuildContext context, String url);
-typedef Widget LoadingErrorWidgetBuilder(
-    BuildContext context, String url, Object error);
+import 'cached_image_types.dart';
 
 class CachedNetworkImage extends StatefulWidget {
   /// Option to use cachemanager with other settings

--- a/lib/src/cached_network_image.dart
+++ b/lib/src/cached_network_image.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'cached_image_types.dart';
+
+// ignore: uri_does_not_exist
+import 'cached_network_image_stub.dart'
+    // ignore: uri_does_not_exist
+    if (dart.library.html) 'browser_cached_network_image.dart'
+    // ignore: uri_does_not_exist
+    if (dart.library.io) 'io_cached_network_image.dart';
+
+abstract class CachedNetworkImage extends StatefulWidget {
+  factory CachedNetworkImage(
+          {Key key,
+          @required String imageUrl,
+          ImageWidgetBuilder imageBuilder,
+          PlaceholderWidgetBuilder placeholder,
+          LoadingErrorWidgetBuilder errorWidget,
+          Duration fadeOutDuration = const Duration(milliseconds: 1000),
+          Curve fadeOutCurve: Curves.easeOut,
+          Duration fadeInDuration = const Duration(milliseconds: 500),
+          Curve fadeInCurve: Curves.easeIn,
+          double width,
+          double height,
+          BoxFit fit,
+          AlignmentGeometry alignment: Alignment.center,
+          ImageRepeat repeat: ImageRepeat.noRepeat,
+          bool matchTextDirection: false,
+          final Map<String, String> httpHeaders,
+          bool useOldImageOnUrlChange: false,
+          Color color,
+          FilterQuality filterQuality: FilterQuality.low,
+          BlendMode colorBlendMode,
+          Duration placeholderFadeInDuration}) =>
+      createCachedNetworkImage(
+          key: key,
+          imageUrl: imageUrl,
+          imageBuilder: imageBuilder,
+          placeholder: placeholder,
+          errorWidget: errorWidget,
+          fadeOutDuration: fadeOutDuration,
+          fadeOutCurve: fadeOutCurve,
+          fadeInDuration: fadeInDuration,
+          fadeInCurve: fadeInCurve,
+          width: width,
+          height: height,
+          fit: fit,
+          alignment: alignment,
+          repeat: repeat,
+          matchTextDirection: matchTextDirection,
+          httpHeaders: httpHeaders,
+          useOldImageOnUrlChange: useOldImageOnUrlChange,
+          color: color,
+          filterQuality: filterQuality,
+          colorBlendMode: colorBlendMode,
+          placeholderFadeInDuration: placeholderFadeInDuration);
+}

--- a/lib/src/cached_network_image_stub.dart
+++ b/lib/src/cached_network_image_stub.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'base_cached_network_image.dart';
+import 'cached_image_types.dart';
+
+/// Implemented in `browser_poly_image.dart` and `io_poly_image.dart`.
+BaseCachedNetworkImage createCachedNetworkImage(
+        {Key key,
+        @required String imageUrl,
+        ImageWidgetBuilder imageBuilder,
+        PlaceholderWidgetBuilder placeholder,
+        LoadingErrorWidgetBuilder errorWidget,
+        Duration fadeOutDuration,
+        Curve fadeOutCurve,
+        Duration fadeInDuration,
+        Curve fadeInCurve,
+        double width,
+        double height,
+        BoxFit fit,
+        AlignmentGeometry alignment,
+        ImageRepeat repeat,
+        bool matchTextDirection,
+        final Map<String, String> httpHeaders,
+        bool useOldImageOnUrlChange,
+        Color color,
+        FilterQuality filterQuality,
+        BlendMode colorBlendMode,
+        Duration placeholderFadeInDuration}) =>
+    throw UnsupportedError('Cannot create without dart:html or dart:io.');

--- a/lib/src/io_cached_network_image.dart
+++ b/lib/src/io_cached_network_image.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+import 'cached_image_widget.dart';
+import 'cached_image_types.dart';
+import 'base_cached_network_image.dart';
+
+BaseCachedNetworkImage createCachedNetworkImage(
+        {Key key,
+        @required String imageUrl,
+        ImageWidgetBuilder imageBuilder,
+        PlaceholderWidgetBuilder placeholder,
+        LoadingErrorWidgetBuilder errorWidget,
+        Duration fadeOutDuration,
+        Curve fadeOutCurve: Curves.easeOut,
+        Duration fadeInDuration,
+        Curve fadeInCurve,
+        double width,
+        double height,
+        BoxFit fit,
+        AlignmentGeometry alignment,
+        ImageRepeat repeat,
+        bool matchTextDirection,
+        final Map<String, String> httpHeaders,
+        bool useOldImageOnUrlChange,
+        Color color,
+        FilterQuality filterQuality,
+        BlendMode colorBlendMode,
+        Duration placeholderFadeInDuration}) =>
+    IoCachedNetworkImage(
+        key: key,
+        imageUrl: imageUrl,
+        imageBuilder: imageBuilder,
+        placeholder: placeholder,
+        errorWidget: errorWidget,
+        fadeOutDuration: fadeOutDuration,
+        fadeOutCurve: fadeOutCurve,
+        fadeInDuration: fadeInDuration,
+        fadeInCurve: fadeInCurve,
+        width: width,
+        height: height,
+        fit: fit,
+        alignment: alignment,
+        repeat: repeat,
+        matchTextDirection: matchTextDirection,
+        httpHeaders: httpHeaders,
+        useOldImageOnUrlChange: useOldImageOnUrlChange,
+        color: color,
+        filterQuality: filterQuality,
+        colorBlendMode: colorBlendMode,
+        placeholderFadeInDuration: placeholderFadeInDuration);
+
+class IoCachedNetworkImage extends BaseCachedNetworkImage {
+  final CachedNetworkImage _instance;
+  IoCachedNetworkImage({Key key,
+      @required String imageUrl,
+      ImageWidgetBuilder imageBuilder,
+      PlaceholderWidgetBuilder placeholder,
+      LoadingErrorWidgetBuilder errorWidget,
+      Duration fadeOutDuration,
+      Curve fadeOutCurve: Curves.easeOut,
+      Duration fadeInDuration,
+      Curve fadeInCurve,
+      double width,
+      double height,
+      BoxFit fit,
+      AlignmentGeometry alignment,
+      ImageRepeat repeat,
+      bool matchTextDirection,
+      final Map<String, String> httpHeaders,
+      bool useOldImageOnUrlChange,
+      Color color,
+      FilterQuality filterQuality,
+      BlendMode colorBlendMode,
+      Duration placeholderFadeInDuration})
+      : _instance = CachedNetworkImage(
+            key: key,
+            imageUrl: imageUrl,
+            imageBuilder: imageBuilder,
+            placeholder: placeholder,
+            errorWidget: errorWidget,
+            fadeOutDuration: fadeOutDuration,
+            fadeOutCurve: fadeOutCurve,
+            fadeInDuration: fadeInDuration,
+            fadeInCurve: fadeInCurve,
+            width: width,
+            height: height,
+            fit: fit,
+            alignment: alignment,
+            repeat: repeat,
+            matchTextDirection: matchTextDirection,
+            httpHeaders: httpHeaders,
+            useOldImageOnUrlChange: useOldImageOnUrlChange,
+            color: color,
+            filterQuality: filterQuality,
+            colorBlendMode: colorBlendMode,
+            placeholderFadeInDuration: placeholderFadeInDuration);
+  @override
+  _IoCachedNetworkImageState createState() => _IoCachedNetworkImageState();
+}
+
+class _IoCachedNetworkImageState extends State<IoCachedNetworkImage> {
+  @override
+  Widget build(BuildContext context) {
+    return widget._instance;
+  }
+}


### PR DESCRIPTION
See 
[Web Support](https://github.com/MoacirSchmidt/flutter_cached_network_image#web-support)

CachedNetworkImageProvider was NOT ported!

Please ignore. I have just found a bug.